### PR TITLE
Add auto-focus for search field

### DIFF
--- a/public/app/app.js
+++ b/public/app/app.js
@@ -40,3 +40,22 @@ app.config(['$routeProvider', '$translateProvider',
         $translateProvider.preferredLanguage('fr');
     }
 ]);
+
+function isCharacterKeyPress(evt) {
+	if (typeof evt.which == "undefined") {
+		// This is IE, which only fires keypress events for printable keys
+		return true;
+	} else if (typeof evt.which == "number" && evt.which > 0) {
+		// In other browsers except old versions of WebKit, evt.which is
+		// only greater than zero if the keypress is a printable key.
+		// We need to filter out backspace and ctrl/alt/meta key combinations
+		return !evt.ctrlKey && !evt.metaKey && !evt.altKey && evt.which != 8;
+	}
+	return false;
+}
+document.addEventListener("keypress", function(evt){
+	evt = evt || window.event;
+	if(isCharacterKeyPress(evt) && document.activeElement == document.body){
+		$('form input').focus().val('');
+	}
+});


### PR DESCRIPTION
This gives focus to the search field when you type something in the page body, which is imo more friendly than having to click on the input.

It relies on jQuery, but it should be present.
